### PR TITLE
Fix compilation errors on OTP 20.1+, when on top of macOS Big Sur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.13.1] - 2020-12-08
+### Fixed
+- `tls_certificate_check` compilation errors on OTP 20.1+, when on top of macOS Big Sur
+
 ## [1.13.0] - 2020-12-05
 ### Changed
 - CA bundles, based on the latest mkcert.org full CA list as of Nov 13, 2020

--- a/rebar.config
+++ b/rebar.config
@@ -24,7 +24,7 @@
 
 {deps,
  [{stacktrace_compat, "1.2.1"},
-  {tls_certificate_check, "1.1.0"}
+  {tls_certificate_check, "1.1.1"}
  ]}.
 
 {erl_first_files,

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,10 +1,10 @@
-{"1.1.0",
+{"1.2.0",
 [{<<"certifi">>,{pkg,<<"certifi">>,<<"2.5.3">>},1},
  {<<"parse_trans">>,{pkg,<<"parse_trans">>,<<"3.3.0">>},1},
  {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.6">>},1},
  {<<"stacktrace_compat">>,{pkg,<<"stacktrace_compat">>,<<"1.2.1">>},0},
  {<<"tls_certificate_check">>,
-  {pkg,<<"tls_certificate_check">>,<<"1.1.0">>},
+  {pkg,<<"tls_certificate_check">>,<<"1.1.1">>},
   0}]}.
 [
 {pkg_hash,[
@@ -12,5 +12,11 @@
  {<<"parse_trans">>, <<"09765507A3C7590A784615CFD421D101AEC25098D50B89D7AA1D66646BC571C1">>},
  {<<"ssl_verify_fun">>, <<"CF344F5692C82D2CD7554F5EC8FD961548D4FD09E7D22F5B62482E5AEAEBD4B0">>},
  {<<"stacktrace_compat">>, <<"EC6B8EA09B68DE061911AD50037E10673C823F4BC15B544DE657949DFB99961B">>},
- {<<"tls_certificate_check">>, <<"397E139994C2EA442675DDD6A797F5FA1EA46AEBA4A6321BDCA5589D5A6ADA23">>}]}
+ {<<"tls_certificate_check">>, <<"2B6647FF87A8291A982458883DCA7D5B39BA305835FE4342BF22E5476D3998C5">>}]},
+{pkg_hash_ext,[
+ {<<"certifi">>, <<"ED516ACB3929B101208A9D700062D520F3953DA3B6B918D866106FFA980E1C10">>},
+ {<<"parse_trans">>, <<"17EF63ABDE837AD30680EA7F857DD9E7CED9476CDD7B0394432AF4BFC241B960">>},
+ {<<"ssl_verify_fun">>, <<"BDB0D2471F453C88FF3908E7686F86F9BE327D065CC1EC16FA4540197EA04680">>},
+ {<<"stacktrace_compat">>, <<"416BEC0A4579C02976B8223AD4EDEA93A1C2E0E80B19977675542B0CAFEDBB99">>},
+ {<<"tls_certificate_check">>, <<"08FD94D68E5C80E172529B9BB89715C95747FF55447A2C833A1205564FA7BFEE">>}]}
 ].


### PR DESCRIPTION
Closes #19 .