### PR TITLE
Adapt to the future

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,4 @@ jobs:
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
-      - run: RUNNING_ON_CI=yes make ci_test check
+      - run: RUNNING_ON_CI=yes make check test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,4 +22,4 @@ jobs:
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2
-      - run: RUNNING_ON_CI=yes make check test
+      - run: RUNNING_ON_CI=yes make test check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,9 @@ jobs:
       image: erlang:${{matrix.otp_vsn}}
     strategy:
       matrix:
-        # Use only latest OTP minor for each supported major, except for:
-        # - 20.0: because of PRIV_DIR_SHENANIGANS (only version affected)
-        # - 21.0: because of NO_LOGGER (which doesn't affect 21.1+)
-        otp_vsn: [19.3, 20.0, 20.3, 21.0, 21.3, 22.3, 23.1]
+        otp_vsn: [21.2, 21.3,
+                  22.0, 22.1, 22.2, 22.3,
+                  23.0, 23.1, 23.2, 23.3]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,3 @@ _build
 rebar3.crashdump
 locus
 *.mmdb
-test/MaxMind-DB

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test/MaxMind-DB"]
+	path = test/MaxMind-DB
+	url = https://github.com/maxmind/MaxMind-DB.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "test/MaxMind-DB"]
-	path = test/MaxMind-DB
-	url = https://github.com/maxmind/MaxMind-DB.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- imported version of `tls_certificate_check` to '~> 1.3'
+
+### Removed
+- unmaintained compatibility with rebar 2
+- `stacktrace_compat' dependency
+- lots of (now-)dead code that dealt with pre- OTP 21.2 differences
+- compatibility with OTP 19
+- compatibility with OTP 20
+- compatibility with OTP 21.0 and 21.1
+
+### Fixed
+- import of MaxMind test data in a way that works both locally and on GHA
+
 ## [1.14.1] - 2021-03-16
 ### Fixed
 - Hex documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Removed
 - unmaintained compatibility with rebar 2
-- `stacktrace_compat' dependency
+- `stacktrace_compat` dependency
 - lots of (now-)dead code that dealt with pre- OTP 21.2 differences
 - compatibility with OTP 19
 - compatibility with OTP 20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 - unmaintained compatibility with rebar 2
 - `stacktrace_compat` dependency
-- lots of (now-)dead code that dealt with pre- OTP 21.2 differences
+- (now-)dead code that dealt with pre- OTP 21.2 differences in `stdlib` and such
 - compatibility with OTP 19
 - compatibility with OTP 20
 - compatibility with OTP 21.0 and 21.1

--- a/Makefile
+++ b/Makefile
@@ -42,11 +42,11 @@ dialyzer: $(REBAR3)
 xref: $(REBAR3)
 	@$(REBAR3) xref
 
-test: $(REBAR3) cli test/MaxMind-DB/test-data
+test: $(REBAR3) cli
 	@$(REBAR3) do eunit, ct, cover
 	./locus analyze --log-level debug test/priv/GeoLite2-Country.tar.gz
 
-ci_test: $(REBAR3) cli test/MaxMind-DB/test-data
+ci_test: $(REBAR3) cli
 	@$(REBAR3) as ci_test eunit, ct, cover
 	./locus analyze --log-level debug test/priv/GeoLite2-Country.tar.gz
 
@@ -76,18 +76,3 @@ publish: $(REBAR3)
 cli: $(REBAR3)
 	@$(REBAR3) as escriptize escriptize
 	cp -p "$(CLI_ARTIFACT_PATH)" ./
-
-test/MaxMind-DB/test-data: .git
-	git submodule update --init --recursive
-	rm -rf test/MaxMind-DB/.git
-
-.git:
-	# If `.git` is missing, then we're likely
-	# running under GitHub Actions.
-	#
-	# Since we need for a repo to exist in order
-	# for submodules to be imported, create a dummy one.
-	git init .
-	git config user.email "dummy@dummy.dummy"
-	git config user.name "Dummy McDummier"
-	git commit --allow-empty -m "Dummy first commit"

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,10 @@ endif
 CLI_ARTIFACT_PATH = _build/escriptize/bin/locus
 
 .PHONY: all build clean check dialyzer xref
-.PHONY: test ci_test cover
+.PHONY: test cover
 .PHONY: shell console doc publish cli
 
-.NOTPARALLEL: check cover test ci_test
+.NOTPARALLEL: check cover test
 
 all: build
 
@@ -44,10 +44,6 @@ xref: $(REBAR3)
 
 test: $(REBAR3) cli
 	@$(REBAR3) do eunit, ct, cover
-	./locus analyze --log-level debug test/priv/GeoLite2-Country.tar.gz
-
-ci_test: $(REBAR3) cli
-	@$(REBAR3) as ci_test eunit, ct, cover
 	./locus analyze --log-level debug test/priv/GeoLite2-Country.tar.gz
 
 cover: test

--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,15 @@ cli: $(REBAR3)
 	@$(REBAR3) as escriptize escriptize
 	cp -p "$(CLI_ARTIFACT_PATH)" ./
 
-test/MaxMind-DB/test-data: test/MaxMind-DB
-	(cd test/MaxMind-DB && git reset --hard d7d482e && rm -rf .git)
+test/MaxMind-DB/test-data: .git
+	git submodule update --init --recursive
+	rm -rf test/MaxMind-DB/.git
 
-test/MaxMind-DB:
-	git clone https://github.com/maxmind/MaxMind-DB.git test/MaxMind-DB
+.git:
+	# If `.git` is missing, then we're likely
+	# running under GitHub Actions.
+	#
+	# Since we need for a repo to exist in order
+	# for submodules to be imported, create a dummy one.
+	git init .
+	git commit --allow-empty -m "Dummy first commit"

--- a/Makefile
+++ b/Makefile
@@ -88,4 +88,6 @@ test/MaxMind-DB/test-data: .git
 	# Since we need for a repo to exist in order
 	# for submodules to be imported, create a dummy one.
 	git init .
+	git config user.email "dummy@dummy.dummy"
+	git config user.name "Dummy McDummier"
 	git commit --allow-empty -m "Dummy first commit"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-locus
-=====
+# locus
 
 [![](https://img.shields.io/hexpm/v/locus.svg?style=flat)](https://hex.pm/packages/locus)
 [![](https://github.com/g-andrade/locus/workflows/build/badge.svg)](https://github.com/g-andrade/locus/actions?query=workflow%3Abuild)
@@ -15,13 +14,13 @@ filesystem and updated automatically.
 > ⚠️ Starting on December 31st, 2019, **a license key is now
 > [required](https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/)
 > to download MaxMind GeoLite2 databases**.
->
+> 
 > Previous URLs have been discontinued; you should upgrade `locus` to a
 > recent version if you used them.
 
 #### Usage
 
-##### 1. Configure your license key
+##### 1\. Configure your license key
 
 **Skip this step if you're not loading databases directly from
 MaxMind.**
@@ -36,22 +35,23 @@ Then clone the repository, run `make shell` and declare your key:
 application:set_env(locus, license_key, "YOUR_LICENSE_KEY").
 ```
 
-##### 2. Start the database loader
+##### 2\. Start the database loader
 
 ``` erlang
 ok = locus:start_loader(country, {maxmind, "GeoLite2-Country"}).
 % You can also use a HTTP URL or a local path, e.g. "/usr/share/GeoIP/GeoLite2-City.mmdb"
 ```
 
-##### 3. Wait for the database to load (optional)
+##### 3\. Wait for the database to load (optional)
 
 ``` erlang
 {ok, _DatabaseVersion} = locus:await_loader(country). % or `{error, Reason}'
 ```
 
-##### 4. Look up IP addresses
+##### 4\. Look up IP addresses
 
 ``` erlang
+
 % > locus:lookup(country, "93.184.216.34").
 % > locus:lookup(country, "2606:2800:220:1:248:1893:25c8:1946").
 
@@ -116,10 +116,10 @@ ok = locus:start_loader(country, {maxmind, "GeoLite2-Country"}).
 
 ##### Supported File Formats
 
--   gzip-compressed tarballs (`.tar.gz`, `.tgz`)
--   plain tarballs (`.tar`)
--   MMDB files (`.mmdb`)
--   gzip-compressed MMDB files (`.mmdb.gz`)
+  - gzip-compressed tarballs (`.tar.gz`, `.tgz`)
+  - plain tarballs (`.tar`)
+  - MMDB files (`.mmdb`)
+  - gzip-compressed MMDB files (`.mmdb.gz`)
 
 For tarball files, the first file to be found within it with an `.mmdb`
 extension is the one that's chosen for loading.
@@ -129,12 +129,12 @@ format](https://maxmind.github.io/MaxMind-DB/) is mostly complete.
 
 ##### Database Types and Loading
 
--   The free GeoLite2 [Country, City and ASN
+  - The free GeoLite2 [Country, City and ASN
     databases](https://dev.maxmind.com/geoip/geoip2/geolite2/) were all
     successfully tested; presumably `locus` can deal with [any MMDB
     database](#alternative-providers) that maps IP address prefixes to
     arbitrary data
--   The databases are loaded into memory (mostly) as is; reference
+  - The databases are loaded into memory (mostly) as is; reference
     counted binaries are shared with the application callers using ETS
     tables, and the original binary search tree is used to lookup
     addresses. The data for each entry is decoded on the fly upon
@@ -153,7 +153,7 @@ the `locus` CLI utility:
     deployed to the current directory.
 
 2.  Run analysis:
-
+    
     ``` shell
     ./locus analyze GeoLite2-City.mmdb
     # Loading database from "GeoLite2-City.mmdb"...
@@ -168,24 +168,24 @@ arguments.
 
 ##### MaxMind sources / HTTP URLs: Downloading and Updating
 
--   The downloaded database files, when compressed, are inflated in
+  - The downloaded database files, when compressed, are inflated in
     memory
--   The `last-modified` response header, if present, is used to
+  - The `last-modified` response header, if present, is used to
     condition subsequent download attempts (using `if-modified-since`
     request headers) in order to save bandwidth
--   The downloaded databases are cached on the filesystem in order to
+  - The downloaded databases are cached on the filesystem in order to
     more quickly achieve readiness on future launches of the database
     loader
--   Database download attempts are retried upon error according to an
+  - Database download attempts are retried upon error according to an
     exponential backoff policy - quickly at first (every few seconds)
     but gradually slowing down to every 15 minutes. Successful and
     dismissed download attempts will be checked for update after 6
     hours. Both of these behaviours can be tweaked through the
     `error_retries` and `update_period` loader settings (see [function
     reference](#api-reference).)
--   When downloading from a MaxMind edition or HTTPS URL, the remote
+  - When downloading from a MaxMind edition or HTTPS URL, the remote
     certificate will be authenticated against a [list of known
-    Certificate Authorities](https://github.com/certifi/erlang-certifi)
+    Certificate Authorities](https://hexdocs.pm/tls_certificate_check/)
     and connection negotiation will fail in case of an expired
     certificate, mismatched hostname, self-signed certificate or unknown
     certificate authority. These checks can be disabled by specifying
@@ -193,25 +193,25 @@ arguments.
 
 ##### MaxMind sources / HTTP URLs: Caching
 
--   Caching is a best effort; the system falls back to relying
+  - Caching is a best effort; the system falls back to relying
     exclusively on the network if needed
--   A caching directory named `locus_erlang` is created under the
+  - A caching directory named `locus_erlang` is created under the
     ['user\_cache'
     basedir](http://erlang.org/doc/man/filename.html#basedir-3)
--   Cached databases are named after the MaxMind database edition name,
+  - Cached databases are named after the MaxMind database edition name,
     or alternatively after the SHA256 hash of their source URL
--   Modification time of the databases is extracted from `last-modified`
+  - Modification time of the databases is extracted from `last-modified`
     response header (when present) and used to condition downloads on
     subsequent boots and save bandwidth
--   Caching can be disabled by specifying the `no_cache` option when
+  - Caching can be disabled by specifying the `no_cache` option when
     running `:start_loader`
 
 ##### Filesystem URLs: Loading and Updating
 
--   The loaded database files, when compressed, are inflated in memory
--   The database file modification timestamp is used to condition
+  - The loaded database files, when compressed, are inflated in memory
+  - The database file modification timestamp is used to condition
     subsequent load attempts in order to lower I/O activity
--   Database load attempts are retried upon error according to an
+  - Database load attempts are retried upon error according to an
     exponential backoff policy - quickly at first (every few seconds)
     but gradually slowing down to every 30 seconds. Successful and
     dismissed load attempts will be checked for update after 30 seconds.
@@ -221,9 +221,9 @@ arguments.
 
 ##### Logging
 
--   Five logging levels are supported: `debug`, `info`, `warning`,
+  - Five logging levels are supported: `debug`, `info`, `warning`,
     `error` and `none`
--   The chosen backend on OTP 21.1+ is
+  - The chosen backend on OTP 21.1+ is
     [logger](http://erlang.org/doc/man/logger.html) **if**
     [lager](https://github.com/erlang-lager/lager/) is either missing or
     it hasn't
@@ -231,18 +231,18 @@ arguments.
     `logger`'s default handler; for all other scenarios,
     [error\_logger](http://erlang.org/doc/man/error_logger.html) is
     picked instead
--   The default log level is `error`; it can be changed in the
+  - The default log level is `error`; it can be changed in the
     application's `env` config
--   To tweak the log level in runtime, use `locus_logger:set_loglevel/1`
+  - To tweak the log level in runtime, use `locus_logger:set_loglevel/1`
 
 ##### Event Subscriptions
 
--   Any number of event subscribers can be attached to a database loader
+  - Any number of event subscribers can be attached to a database loader
     by specifying the `{event_subscriber, Subscriber}` option when
     starting the database
--   A `Subscriber` can be either a module implementing the
+  - A `Subscriber` can be either a module implementing the
     `locus_event_subscriber` behaviour or an arbitrary `pid()`
--   The format and content of reported events can be consulted in detail
+  - The format and content of reported events can be consulted in detail
     on the `locus_event_subscriber` module documentation; most key steps
     in the loader pipeline are reported (download started, download
     succeeded, download failed, caching succeeded, loading failed, etc.)
@@ -253,8 +253,8 @@ The API reference can be found on [HexDocs](https://hexdocs.pm/locus/).
 
 ##### Tested setup
 
--   Erlang/OTP 19 or newer
--   rebar3
+  - Erlang/OTP 21.2 or newer
+  - rebar3
 
 ##### License
 
@@ -286,40 +286,40 @@ sponsored, or otherwise approved by MaxMind.
 
 ##### Alternative Providers
 
--   [DB-IP.com](https://db-ip.com/db/): lite databases seem to work but
+  - [DB-IP.com](https://db-ip.com/db/): lite databases seem to work but
     setting up auto-update for them is not practical, as there's no
     "latest" URL.
 
 ##### Alternative Libraries (Erlang)
 
--   [egeoip](https://github.com/mochi/egeoip): IP Geolocation module,
+  - [egeoip](https://github.com/mochi/egeoip): IP Geolocation module,
     currently supporting the MaxMind GeoLite City Database
--   [geodata2](https://github.com/brigadier/geodata2): Application for
+  - [geodata2](https://github.com/brigadier/geodata2): Application for
     working with MaxMind geoip2 (.mmdb) databases
--   [geoip](https://github.com/manifest/geoip): Returns the location of
+  - [geoip](https://github.com/manifest/geoip): Returns the location of
     an IP address; based on the ipinfodb.com web service
--   [geolite2data](https://hex.pm/packages/geolite2data): Periodically
+  - [geolite2data](https://hex.pm/packages/geolite2data): Periodically
     fetches the free MaxMind GeoLite2 databases
--   [ip2location-erlang](https://github.com/ip2location/ip2location-erlang):
+  - [ip2location-erlang](https://github.com/ip2location/ip2location-erlang):
     Uses IP2Location geolocation database
 
 ##### Alternative Libraries (Elixir)
 
--   [asn](https://hex.pm/packages/asn): IP-to-AS-to-ASname lookup
--   [freegeoip](https://hex.pm/packages/freegeoip): Simple wrapper for
+  - [asn](https://hex.pm/packages/asn): IP-to-AS-to-ASname lookup
+  - [freegeoip](https://hex.pm/packages/freegeoip): Simple wrapper for
     freegeoip.net HTTP API
--   [freegeoipx](https://hex.pm/packages/freegeoipx): API Client for
+  - [freegeoipx](https://hex.pm/packages/freegeoipx): API Client for
     freegeoip.net
--   [geoip](https://hex.pm/packages/geoip): Lookup the geo location for
+  - [geoip](https://hex.pm/packages/geoip): Lookup the geo location for
     a given IP address, hostname or Plug.Conn instance
--   [geolix](https://hex.pm/packages/geolix): MaxMind GeoIP2 database
+  - [geolix](https://hex.pm/packages/geolix): MaxMind GeoIP2 database
     reader/decoder
--   [plug\_geoip2](https://hex.pm/packages/plug_geoip2): Adds geo
+  - [plug\_geoip2](https://hex.pm/packages/plug_geoip2): Adds geo
     location to a Plug connection based upon the client IP address by
     using MaxMind's GeoIP2 database
--   [tz\_world](https://hex.pm/packages/tz_world): Resolve timezones
+  - [tz\_world](https://hex.pm/packages/tz_world): Resolve timezones
     from a location efficiently using PostGIS and Ecto
 
-------------------------------------------------------------------------
+-----
 
 *Generated by EDoc*

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -249,7 +249,7 @@ The API reference can be found on <a target="_parent" href="https://hexdocs.pm/l
 <h5 id="tested-setup">Tested setup</h5>
 
 <ul>
-<li>Erlang/OTP 19 or newer</li>
+<li>Erlang/OTP 21.2 or newer</li>
 <li>rebar3</li>
 </ul>
 

--- a/doc/overview.edoc
+++ b/doc/overview.edoc
@@ -181,7 +181,7 @@ Run `./locus analyze --help' for a description of supported options and argument
   loader settings (see <a href="#api-reference">function reference</a>.)
   </li>
 <li>When downloading from a MaxMind edition or HTTPS URL, the remote certificate will be authenticated
-  against a <a target="_parent" href="https://github.com/certifi/erlang-certifi">list of known Certificate Authorities</a>
+  against a <a target="_parent" href="https://hexdocs.pm/tls_certificate_check/">list of known Certificate Authorities</a>
   and connection negotiation will fail in case of an expired certificate, mismatched hostname,
   self-signed certificate or unknown certificate authority.
   These checks can be disabled by specifying the `insecure' loader option.

--- a/rebar.config
+++ b/rebar.config
@@ -16,7 +16,7 @@
 {minimum_otp_vsn, "21.2"}.
 
 {deps,
- [{tls_certificate_check, "1.2.0"}
+ [{tls_certificate_check, "~> 1.3"}
  ]}.
 
 {erl_first_files,

--- a/rebar.config
+++ b/rebar.config
@@ -81,15 +81,6 @@
       nowarn_export_all,
       nowarn_missing_spec,
       nowarnings_as_errors]}
-   ]},
-
-  {ci_test,
-   [{erl_opts,
-     [debug_info,
-      nowarn_export_all,
-      nowarn_missing_spec,
-      nowarnings_as_errors,
-      {d, 'RUNNING_ON_CI'}]}
    ]}
  ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -12,9 +12,6 @@
   warn_unused_import,
   warnings_as_errors,
   {parse_transform, stacktrace_transform},
-  {platform_define, "^1",                  'NO_LOGGER'},
-  {platform_define, "^20",                 'NO_LOGGER'},
-  {platform_define, "^21.0",               'NO_LOGGER'}, % `:set_application_level/2` requires 21.1+
   {platform_define, "^19",                 'NO_GEN_SERVER_HIBERNATE_AFTER'},
   {platform_define, "^((2[3-9])|([3-9]))", 'HTTP_URI_PARSE_DEPRECATED'},
   {platform_define, "^20.0",               'PRIV_DIR_SHENANIGANS'}

--- a/rebar.config
+++ b/rebar.config
@@ -10,15 +10,13 @@
   warn_obsolete_guards,
   warn_shadow_vars,
   warn_unused_import,
-  warnings_as_errors,
-  {parse_transform, stacktrace_transform}
+  warnings_as_errors
  ]}.
 
 {minimum_otp_vsn, "21.2"}.
 
 {deps,
- [{stacktrace_compat, "1.2.1"},
-  {tls_certificate_check, "1.2.0"}
+ [{tls_certificate_check, "1.2.0"}
  ]}.
 
 {erl_first_files,

--- a/rebar.config
+++ b/rebar.config
@@ -11,8 +11,7 @@
   warn_shadow_vars,
   warn_unused_import,
   warnings_as_errors,
-  {parse_transform, stacktrace_transform},
-  {platform_define, "^20.0",               'PRIV_DIR_SHENANIGANS'}
+  {parse_transform, stacktrace_transform}
  ]}.
 
 {minimum_otp_vsn, "21.2"}.

--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,6 @@
   warn_unused_import,
   warnings_as_errors,
   {parse_transform, stacktrace_transform},
-  {platform_define, "^((2[3-9])|([3-9]))", 'HTTP_URI_PARSE_DEPRECATED'},
   {platform_define, "^20.0",               'PRIV_DIR_SHENANIGANS'}
  ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -20,7 +20,7 @@
   {platform_define, "^20.0",               'PRIV_DIR_SHENANIGANS'}
  ]}.
 
-{minimum_otp_vsn, "19"}.
+{minimum_otp_vsn, "21.2"}.
 
 {deps,
  [{stacktrace_compat, "1.2.1"},

--- a/rebar.config
+++ b/rebar.config
@@ -70,7 +70,11 @@
 
   {test,
    [{deps,
-     [{jsx, "3.0.0"}
+     [{jsx, "3.0.0"},
+      {maxmind_test_data, {raw, {git, "https://github.com/maxmind/MaxMind-DB.git", {ref, "d7d482e"}}}}
+     ]},
+    {plugins,
+     [{rebar_raw_resource, "0.10.0"}
      ]},
     {erl_opts,
      [debug_info,

--- a/rebar.config
+++ b/rebar.config
@@ -12,7 +12,6 @@
   warn_unused_import,
   warnings_as_errors,
   {parse_transform, stacktrace_transform},
-  {platform_define, "^19",                 'NO_GEN_SERVER_HIBERNATE_AFTER'},
   {platform_define, "^((2[3-9])|([3-9]))", 'HTTP_URI_PARSE_DEPRECATED'},
   {platform_define, "^20.0",               'PRIV_DIR_SHENANIGANS'}
  ]}.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -10,40 +10,18 @@ of
         % no override needed
         CONFIG;
     {deps, {_, Deps}} ->
-        %
-        % rebar 2.x - convert deps to old format
-        % THIS MAY STOP WORKING AT ANY MOMENT.
-        % USE AT YOUR OWN RISK.
-        %
-        error_logger:warning_msg("~n~n"
-                                 "\t!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!~n"
-                                 "\t!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!~n"
-                                 "\t*********************************************************************~n"
-                                 "\t~n"
-                                 "\t[locus] You're **strongly** incentivized to use `rebar3`.~n"
-                                 "\tCompatibility with rebar 2 is unmaintained and will be removed in the near future.~n"
-                                 "\t~n"
-                                 "\t*********************************************************************~n"
-                                 "\t!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!~n"
-                                 "\t!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!~n"),
-
-        {_, ErlOpts} = lists:keyfind(erl_opts, 1, CONFIG),
-        OverriddenErlOpts = ErlOpts -- [warn_missing_spec],
-        OverriddenSortableDeps =
-            lists:foldr(
-              fun ({tls_certificate_check, Version}, Acc) ->
-                      [{1, {tls_certificate_check, ".*",
-                            {git, "https://github.com/g-andrade/tls_certificate_check.git",
-                             {tag, Version}}}}
-                       | Acc];
-                  ({Name, Version}, _Acc) ->
-                      MsgErrorIo = io_lib:format("Hex package '~ts', version \"~ts\": missing Git repo",
-                                                 [Name, Version]),
-                      error(MsgErrorIo)
-              end,
-              [], Deps),
-
-        OverriddenDeps = [element(2, Pair) || Pair <- lists:keysort(1, OverriddenSortableDeps)],
-        Config2 = lists:keystore(deps, 1, CONFIG, {deps,OverriddenDeps}),
-        lists:keystore(erl_opts, 1, Config2, {erl_opts,OverriddenErlOpts})
+        error_logger:error_msg("~n~n"
+                               "\t!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!~n"
+                               "\t!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!~n"
+                               "\t*********************************************************************~n"
+                               "\t~n"
+                               "\tThis library is no longer compatible with rebar 2 because it imports~n"
+                               "\tone or more of its dependencies as transitive ones.~n"
+                               "\t~n"
+                               "\tThe last version that _may_ still work is 1.14.1.~n"
+                               "\t~n"
+                               "\t*********************************************************************~n"
+                               "\t!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!~n"
+                               "\t!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!~n"),
+        init:stop(_Status = 1)
 end.

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -31,13 +31,8 @@ of
         OverriddenErlOpts = ErlOpts -- [warn_missing_spec],
         OverriddenSortableDeps =
             lists:foldr(
-              fun ({stacktrace_compat, Version}, Acc) ->
-                      [{1, {stacktrace_compat, ".*",
-                            {git, "https://github.com/g-andrade/stacktrace_compat.git",
-                             {tag, Version}}}}
-                       | Acc];
-                  ({tls_certificate_check, Version}, Acc) ->
-                      [{2, {tls_certificate_check, ".*",
+              fun ({tls_certificate_check, Version}, Acc) ->
+                      [{1, {tls_certificate_check, ".*",
                             {git, "https://github.com/g-andrade/tls_certificate_check.git",
                              {tag, Version}}}}
                        | Acc];

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,13 +1,13 @@
 {"1.2.0",
 [{<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.6">>},1},
  {<<"tls_certificate_check">>,
-  {pkg,<<"tls_certificate_check">>,<<"1.2.0">>},
+  {pkg,<<"tls_certificate_check">>,<<"1.3.0">>},
   0}]}.
 [
 {pkg_hash,[
  {<<"ssl_verify_fun">>, <<"CF344F5692C82D2CD7554F5EC8FD961548D4FD09E7D22F5B62482E5AEAEBD4B0">>},
- {<<"tls_certificate_check">>, <<"0659E00301A0907A049A35E4E3F7FAC4E2E26783EB6CCD54B917F26638A6BE9D">>}]},
+ {<<"tls_certificate_check">>, <<"B7A02965E0CC8565C8BA8EF6482A72EC5DD3269E1E4F6DBAD533FCBCB0AAB68D">>}]},
 {pkg_hash_ext,[
  {<<"ssl_verify_fun">>, <<"BDB0D2471F453C88FF3908E7686F86F9BE327D065CC1EC16FA4540197EA04680">>},
- {<<"tls_certificate_check">>, <<"5435F4058141CB99B3F7CB15F84B9ACA320CF143F9CB3CC32840A4BC366D6FF7">>}]}
+ {<<"tls_certificate_check">>, <<"2E708E335D30ED6D43ACA4EA8A57AA3D9250F086EB21E0BC7AF5C6CF26C2858E">>}]}
 ].

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,16 +1,13 @@
 {"1.2.0",
 [{<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.6">>},1},
- {<<"stacktrace_compat">>,{pkg,<<"stacktrace_compat">>,<<"1.2.1">>},0},
  {<<"tls_certificate_check">>,
   {pkg,<<"tls_certificate_check">>,<<"1.2.0">>},
   0}]}.
 [
 {pkg_hash,[
  {<<"ssl_verify_fun">>, <<"CF344F5692C82D2CD7554F5EC8FD961548D4FD09E7D22F5B62482E5AEAEBD4B0">>},
- {<<"stacktrace_compat">>, <<"EC6B8EA09B68DE061911AD50037E10673C823F4BC15B544DE657949DFB99961B">>},
  {<<"tls_certificate_check">>, <<"0659E00301A0907A049A35E4E3F7FAC4E2E26783EB6CCD54B917F26638A6BE9D">>}]},
 {pkg_hash_ext,[
  {<<"ssl_verify_fun">>, <<"BDB0D2471F453C88FF3908E7686F86F9BE327D065CC1EC16FA4540197EA04680">>},
- {<<"stacktrace_compat">>, <<"416BEC0A4579C02976B8223AD4EDEA93A1C2E0E80B19977675542B0CAFEDBB99">>},
  {<<"tls_certificate_check">>, <<"5435F4058141CB99B3F7CB15F84B9ACA320CF143F9CB3CC32840A4BC366D6FF7">>}]}
 ].

--- a/src/locus_database.erl
+++ b/src/locus_database.erl
@@ -63,9 +63,7 @@
 %% Macro Definitions
 %% ------------------------------------------------------------------
 
--ifndef(NO_GEN_SERVER_HIBERNATE_AFTER).
 -define(HIBERNATE_AFTER, (timer:seconds(5))).
--endif.
 
 -define(DEFAULT_HTTP_UNREADY_UPDATE_PERIOD, (timer:minutes(1))).
 -define(DEFAULT_HTTP_READY_UPDATE_PERIOD, (timer:hours(6))).
@@ -157,7 +155,7 @@ stop(Id) ->
 %% @private
 start_link(Id, Origin, Opts) ->
     ServerName = server_name(Id),
-    ServerOpts = server_opts(),
+    ServerOpts = [{hibernate_after, ?HIBERNATE_AFTER}],
     gen_server:start_link({local,ServerName}, ?MODULE, [Id, Origin, Opts], ServerOpts).
 
 -spec dynamic_child_spec(term()) -> supervisor:child_spec().
@@ -282,12 +280,6 @@ server_name(Id) ->
       ++ "."
       ++ atom_to_list(Id)
      ).
-
--ifndef(NO_GEN_SERVER_HIBERNATE_AFTER).
-server_opts() -> [{locus_util:dialyzer_opaque_atom(hibernate_after), ?HIBERNATE_AFTER}].
--else.
-server_opts() -> [].
--endif.
 
 -spec validate_opts(origin(), list())
         -> {ok, {[database_opt()], [locus_loader:loader_opt()], [locus_loader:fetcher_opt()]}} |

--- a/src/locus_filesystem_store.erl
+++ b/src/locus_filesystem_store.erl
@@ -143,8 +143,7 @@ handle_write(State) ->
             notify_owner({finished, success}, State),
             {stop, normal, State}
     catch
-        Class:Reason ->
-            Stacktrace = erlang:get_stacktrace(),
+        Class:Reason:Stacktrace ->
             SaferReason = locus_util:purge_term_of_very_large_binaries(Reason),
             SaferStacktrace = locus_util:purge_term_of_very_large_binaries(Stacktrace),
             notify_owner({finished, {error,{Class,SaferReason,SaferStacktrace}}}, State),

--- a/src/locus_loader.erl
+++ b/src/locus_loader.erl
@@ -689,8 +689,7 @@ decode_database_from_tgz_blob(Source, Blob) ->
         Tarball ->
             decode_database_from_tarball_blob(Source, Tarball)
     catch
-        Class:Reason ->
-            Stacktrace = erlang:get_stacktrace(),
+        Class:Reason:Stacktrace ->
             SaferReason = locus_util:purge_term_of_very_large_binaries(Reason),
             SaferStacktrace = locus_util:purge_term_of_very_large_binaries(Stacktrace),
             {error, {decode_database_from_tgz_blob, {Class, SaferReason, SaferStacktrace}}}
@@ -706,8 +705,7 @@ decode_database_from_gzip_blob(Source, Blob) ->
         Uncompressed ->
             decode_database_from_unknown_blob(Source, Uncompressed)
     catch
-        Class:Reason ->
-            Stacktrace = erlang:get_stacktrace(),
+        Class:Reason:Stacktrace ->
             SaferReason = locus_util:purge_term_of_very_large_binaries(Reason),
             SaferStacktrace = locus_util:purge_term_of_very_large_binaries(Stacktrace),
             {error, {decode_database_from_gzip_blob, {Class, SaferReason, SaferStacktrace}}}
@@ -722,8 +720,7 @@ decode_database_from_gzipped_mmdb_blob(Source, Blob) ->
         Uncompressed ->
             decode_database_from_mmdb_blob(Source, Uncompressed)
     catch
-        Class:Reason ->
-            Stacktrace = erlang:get_stacktrace(),
+        Class:Reason:Stacktrace ->
             SaferReason = locus_util:purge_term_of_very_large_binaries(Reason),
             SaferStacktrace = locus_util:purge_term_of_very_large_binaries(Stacktrace),
             {error, {decode_database_from_gzipped_mmdb_blob, {Class, SaferReason, SaferStacktrace}}}
@@ -750,8 +747,7 @@ decode_database_from_tarball_blob(Source, Tarball) ->
         BinDatabase ->
             decode_database_from_mmdb_blob(Source, BinDatabase)
     catch
-        Class:Reason ->
-            Stacktrace = erlang:get_stacktrace(),
+        Class:Reason:Stacktrace ->
             SaferReason = locus_util:purge_term_of_very_large_binaries(Reason),
             SaferStacktrace = locus_util:purge_term_of_very_large_binaries(Stacktrace),
             {error, {decode_database_from_tarball_blob, {Class, SaferReason, SaferStacktrace}}}
@@ -765,8 +761,7 @@ decode_database_from_mmdb_blob(Source, BinDatabase) ->
         {Version, Parts} ->
             {ok, Version, Parts, BinDatabase}
     catch
-        Class:Reason ->
-            Stacktrace = erlang:get_stacktrace(),
+        Class:Reason:Stacktrace ->
             SaferReason = locus_util:purge_term_of_very_large_binaries(Reason),
             SaferStacktrace = locus_util:purge_term_of_very_large_binaries(Stacktrace),
             {error, {decode_database_from_mmdb_blob, {Class, SaferReason, SaferStacktrace}}}

--- a/src/locus_loader.erl
+++ b/src/locus_loader.erl
@@ -65,9 +65,7 @@
 %% Macro Definitions
 %% ------------------------------------------------------------------
 
--ifndef(NO_GEN_SERVER_HIBERNATE_AFTER).
 -define(HIBERNATE_AFTER, (timer:seconds(5))).
--endif.
 
 -define(is_pos_integer(V), ((is_integer((V)) andalso ((V) >= 1)))).
 
@@ -212,7 +210,7 @@ validate_opts(Origin, MixedOpts) ->
 %% @private
 start_link(DatabaseId, Origin, LoaderOpts, FetcherOpts) ->
     Opts = [self(), DatabaseId, Origin, LoaderOpts, FetcherOpts],
-    ServerOpts = server_opts(),
+    ServerOpts = [{hibernate_after, ?HIBERNATE_AFTER}],
     gen_server:start_link(?MODULE, Opts, ServerOpts).
 
 %% ------------------------------------------------------------------
@@ -287,12 +285,6 @@ code_change(_OldVsn, #state{} = State, _Extra) ->
 %% ------------------------------------------------------------------
 %% Internal Function Definitions - Initialization
 %% ------------------------------------------------------------------
-
--ifndef(NO_GEN_SERVER_HIBERNATE_AFTER).
-server_opts() -> [{locus_util:dialyzer_opaque_atom(hibernate_after), ?HIBERNATE_AFTER}].
--else.
-server_opts() -> [].
--endif.
 
 -spec validate_fetcher_opts(origin(), list())
         -> {ok, {[fetcher_opt()], list()}} |

--- a/src/locus_logger.erl
+++ b/src/locus_logger.erl
@@ -84,30 +84,20 @@
 %% ------------------------------------------------------------------
 
 -spec on_app_start() -> ok.
--ifdef(NO_LOGGER).
-%% @private
-on_app_start() -> ok.
--else.
 %% @private
 on_app_start() ->
     CurrentLevel = application:get_env(locus, log_level, undefined),
     _ = logger:set_application_level(locus, CurrentLevel),
     ok.
--endif.
 
 %% @doc Changes the logging verbosity in runtime
 %%
 %% `Level' must be either `debug', `info', `warning', `error' or `none'.
 -spec set_loglevel(debug | info | warning | error | none) -> ok.
--ifdef(NO_LOGGER).
-set_loglevel(Level) when ?is_loglevel(Level) ->
-    application:set_env(locus, log_level, Level).
--else.
 set_loglevel(Level) when ?is_loglevel(Level) ->
     application:set_env(locus, log_level, Level),
     _ = logger:set_application_level(locus, Level),
     ok.
--endif.
 
 %% ------------------------------------------------------------------
 %% locus_event_subscriber Function Definitions
@@ -247,19 +237,6 @@ report_http_download_event(MinWeight, DatabaseId, DownloadType, {download_finish
            ok
     end.
 
--ifdef(NO_LOGGER).
-log_info(Fmt, Args) ->
-    log_to_error_logger(info_msg, Fmt, Args).
-
--spec log_warning(string(), list()) -> ok.
-%% @private
-log_warning(Fmt, Args) ->
-    log_to_error_logger(warning_msg, Fmt, Args).
-
-log_error(Fmt, Args) ->
-    log_to_error_logger(error_msg, Fmt, Args).
-
--else.
 log_info(Fmt, Args) ->
     case use_error_logger() of
         true -> log_to_error_logger(info_msg, Fmt, Args);
@@ -300,7 +277,6 @@ has_usable_logger() ->
     %% The config is set (lager didn't remove it)
     erlang:function_exported(logger, get_handler_config, 1) andalso
     logger:get_handler_config(default) =/= {error, {not_found, default}}.
--endif.
 
 log_to_error_logger(Fun, Fmt, Args) ->
     FullFmt = "[locus] " ++ Fmt ++ "~n",

--- a/src/locus_mmdb.erl
+++ b/src/locus_mmdb.erl
@@ -202,8 +202,7 @@ lookup_(Address, DatabaseParts) ->
         {error, Reason} ->
             {error, Reason}
     catch
-        Class:Reason ->
-            Stacktrace = erlang:get_stacktrace(),
+        Class:Reason:Stacktrace ->
             SaferReason = locus_util:purge_term_of_very_large_binaries(Reason),
             SaferStacktrace = locus_util:purge_term_of_very_large_binaries(Stacktrace),
             erlang:raise(Class, SaferReason, SaferStacktrace)

--- a/src/locus_mmdb_analysis.erl
+++ b/src/locus_mmdb_analysis.erl
@@ -94,8 +94,7 @@ run(DatabaseParts) ->
                 {error, {coordinator_stopped, CoordinatorPid, Reason}}
         end
     catch
-        ExcClass:ExcReason ->
-            Stacktrace = erlang:get_stacktrace(),
+        ExcClass:ExcReason:Stacktrace ->
             SaferReason = locus_util:purge_term_of_very_large_binaries(ExcReason),
             SaferStacktrace = locus_util:purge_term_of_very_large_binaries(Stacktrace),
             true = process_flag(trap_exit, PrevTrapExit),

--- a/src/locus_util.erl
+++ b/src/locus_util.erl
@@ -40,7 +40,6 @@
     lists_take/2,
     bin_to_hex_str/1,
     expect_linked_process_termination/1,
-    dialyzer_opaque_atom/1,
     url_query_encode/1,
     filesystem_safe_name/1,
     is_utf8_binary/1,
@@ -50,10 +49,6 @@
     resolve_http_location/2,
     censor_url_query/2,
     parse_absolute_http_url/1
-   ]).
-
--ignore_xref(
-   [dialyzer_opaque_atom/1
    ]).
 
 %% ------------------------------------------------------------------
@@ -127,10 +122,6 @@ expect_linked_process_termination(Pid) ->
             exit(Pid, kill),
             flush_link_exit(Pid, 1000)
     end.
-
--spec dialyzer_opaque_atom(atom()) -> atom().
-dialyzer_opaque_atom(Atom) ->
-    list_to_atom( atom_to_list(Atom) ).
 
 -spec url_query_encode(unicode:chardata()) -> binary().
 url_query_encode(Chardata) ->

--- a/src/locus_util.erl
+++ b/src/locus_util.erl
@@ -255,7 +255,6 @@ censor_url_query(URL, KeysToCensor) ->
            | {error, not_absolute_http_url}
            | {error, {atom(), term()}}.
 parse_absolute_http_url(URI) ->
-    % TODO reevaluate the need to keep this
     case uri_string:parse(URI) of
         #{scheme := SchemeStr, host := Host} = ParsedURI
           when (SchemeStr =:= "http" orelse SchemeStr =:= "https"),

--- a/src/locus_util.erl
+++ b/src/locus_util.erl
@@ -249,13 +249,13 @@ censor_url_query(URL, KeysToCensor) ->
             URL
     end.
 
--ifdef(HTTP_URI_PARSE_DEPRECATED).
 -spec parse_absolute_http_url(string())
         -> {ok, {atom(), string(), string(), inet:port_number(),
                  string(), string(), string()}}
            | {error, not_absolute_http_url}
            | {error, {atom(), term()}}.
 parse_absolute_http_url(URI) ->
+    % TODO reevaluate the need to keep this
     case uri_string:parse(URI) of
         #{scheme := SchemeStr, host := Host} = ParsedURI
           when (SchemeStr =:= "http" orelse SchemeStr =:= "https"),
@@ -288,25 +288,6 @@ parse_absolute_http_url(URI) ->
         {error, Reason, Context} ->
             {error, {Reason, Context}}
     end.
--else.
--spec parse_absolute_http_url(string())
-        -> {ok, {atom(), string(), string(), inet:port_number(),
-                 string(), string(), string()}}
-           | {error, term()}.
-parse_absolute_http_url(URI) ->
-    case http_uri:parse(URI, [{fragment, true}]) of
-        {ok, {Scheme, _, Host, _, _, _, _}} = Success
-          when (Scheme =:= http orelse Scheme =:= https),
-               length(Host) > 0 ->
-            Success;
-        {ok, _} ->
-            {error, not_absolute_http_url};
-        {error, no_scheme} ->
-            {error, not_absolute_http_url};
-        {error, _} = Error ->
-            Error
-    end.
--endif.
 
 %% ------------------------------------------------------------------
 %% Internal Function Definitions

--- a/test/locus_SUITE.erl
+++ b/test/locus_SUITE.erl
@@ -61,10 +61,6 @@ groups() ->
             ++ [{remote_http_tests, [], test_cases("_httptest")}]
     end.
 
--ifdef(RUNNING_ON_CI).
-should_run_remote_http_tests() ->
-    false.
--else.
 should_run_remote_http_tests() ->
     currently_checkedout_commit_is_likely_tagged()
     andalso license_key_from_environment_is_defined().
@@ -81,8 +77,6 @@ currently_checkedout_commit_is_likely_tagged() ->
 license_key_from_environment_is_defined() ->
     LicenseKey = license_key_from_environment(),
     LicenseKey =/= false andalso length(LicenseKey) > 0.
-
--endif.
 
 license_key_from_environment() ->
     os:getenv("MAXMIND_LICENSE_KEY").

--- a/test/locus_SUITE.erl
+++ b/test/locus_SUITE.erl
@@ -173,13 +173,6 @@ end_per_group(GroupName, Config) ->
             Config
     end.
 
--ifdef(PRIV_DIR_SHENANIGANS).
-path_with_test_tarballs() ->
-    % Work around mind-boggling behaviour in OTP 20.0
-    % for which I realy don't the time.
-    "../../../../test/priv".
-
--else.
 path_with_test_tarballs() ->
     PrivDir = priv_dir(locus),
     BuildRoot = filename:dirname(PrivDir),
@@ -194,8 +187,6 @@ priv_dir(App) ->
         Priv ->
             Priv
     end.
-
--endif. % endif(PRIV_DIR_SHENANIGANS)
 
 %% ------------------------------------------------------------------
 %% Test Cases

--- a/test/maxmind_bad_mmdb_SUITE.erl
+++ b/test/maxmind_bad_mmdb_SUITE.erl
@@ -27,7 +27,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -define(PROJECT_ROOT, "../../../../").
--define(DATABASES_ROOT_DIR, "test/MaxMind-DB/bad-data").
+-define(DATABASES_ROOT_DIR, "_build/test/lib/maxmind_test_data/bad-data").
 
 %% ------------------------------------------------------------------
 %% Setup

--- a/test/maxmind_bad_mmdb_SUITE.erl
+++ b/test/maxmind_bad_mmdb_SUITE.erl
@@ -91,8 +91,7 @@ expect_database_decode_failure(TailPath) ->
             ct:pal("Database version ~p successfully decoded", [Version]),
             error(unexpected_success)
     catch
-        Class:Reason ->
-            Stacktrace = erlang:get_stacktrace(),
+        Class:Reason:Stacktrace ->
             SaferReason = locus_util:purge_term_of_very_large_binaries(Reason),
             SaferStacktrace = locus_util:purge_term_of_very_large_binaries(Stacktrace),
             ct:pal("Unable to decode database because of ~p:~p on ~p",

--- a/test/maxmind_main_mmdb_SUITE.erl
+++ b/test/maxmind_main_mmdb_SUITE.erl
@@ -27,8 +27,8 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -define(PROJECT_ROOT, "../../../../").
--define(TEST_SOURCES_REL_PATH, "test/MaxMind-DB/source-data/").
--define(TEST_DBS_REL_PATH, "test/MaxMind-DB/test-data/").
+-define(TEST_SOURCES_REL_PATH, "_build/test/lib/maxmind_test_data/source-data/").
+-define(TEST_DBS_REL_PATH, "_build/test/lib/maxmind_test_data/test-data/").
 
 -define(BLACKLIST, ["MaxMind-DB-no-ipv4-search-tree",
                     "MaxMind-DB-test-metadata-pointers"]).

--- a/test/maxmind_main_mmdb_SUITE.erl
+++ b/test/maxmind_main_mmdb_SUITE.erl
@@ -40,13 +40,6 @@
 all() ->
     [{group, GroupName} || {GroupName, _Options, _TestCases} <- groups()].
 
--ifdef(RUNNING_ON_CI).
-groups() ->
-    % This suite is too heavy for Travis. It runs ok but screws up
-    % locus_SUITE which runs right after, e.g. with unexpected timeouts.
-    % Probably CPU throttling of some sort.
-    [].
--else.
 groups() ->
     DatabasePathsPattern = filename:join([?PROJECT_ROOT, ?TEST_DBS_REL_PATH, "*.mmdb"]),
     DatabasePaths = filelib:wildcard(DatabasePathsPattern),
@@ -61,7 +54,6 @@ groups() ->
                end)
       end,
       DatabasePaths).
--endif.
 
 test_cases() ->
     Exports = ?MODULE:module_info(exports),


### PR DESCRIPTION
Import latest `tls_certificate_check` and drop `stacktrace_compat` - these changes alone push us into the OTP 21.2+ realm. 
Following said bump, lots of (now-)dead code and hacks were dropped.

Additionally, `tls_certificate_check` is now imported as a transitive dependency to allow for our consumers to seamlessly upgrade to the latest CAs without us interfering - since I maintain `tls_certificate_check` myself, I rest assured there will be no breakage under any upcoming `1.x` version.

Finally, due to `tls_certificate_check` now being faced as a transitive dependency, the hack that allowed rebar 2 to keep working (as requested in #13, some time ago) is no longer feasible; therefore it's dropped for good (it was "unmaintained", in any case - this was bound to happen one day.)

This PR is best viewed on a per-commit basis.

cc: @paulo-ferraz-oliveira 