### PR TITLE
Fix arguments for starting custom_fetcher database loader in Readme.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- wrong reference to custom database fetcher in README [Bartosz Szafran]
+
 ## [2.2.1] - 2021-09-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ ok = locus:start_loader(country, {maxmind, "GeoLite2-Country"}).
 % You can also use:
 % * an HTTP(S) URL,
 % * or a local path, e.g. "/usr/share/GeoIP/GeoLite2-City.mmdb"
-% * or a {custom, Module, Args} tuple, with Module
+% * or a {custom_fetcher, Module, Args} tuple, with Module
 %   implementing the locus_custom_fetcher behaviour.
 ```
 


### PR DESCRIPTION
According to code in `locus.loader_child_spec/2` function, the tuple representing `custom_fetcher` should have atom `custom_fetcher` instead of `custom` as first element.