### PR TITLE
Allow to customise cache file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,8 @@ arguments.
   - Caching can be disabled by specifying the `no_cache` option when
     running `:start_loader`
   - The cache database location can be customised by providing
-    `{database_cache_file, FilePath}` option for `locus_loader`.
+    `{database_cache_file, FilePath}` option for `locus_loader`
+    (`FilePath` must have a ".mmdb.gz" extension)
 
 ### Local sources: Loading and Updating
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ arguments.
 
   - Caching is a best effort; the system falls back to relying
     exclusively on the network if needed
-  - A caching directory named `locus_erlang` is created under the
+  - By default a caching directory named `locus_erlang` is created under the
     ['user\_cache'
     basedir](http://erlang.org/doc/man/filename.html#basedir-3)
   - A cached database is named after either:
@@ -224,6 +224,8 @@ arguments.
         callbacks (for databases loaded with `locus_custom_fetcher``)
   - Caching can be disabled by specifying the `no_cache` option when
     running `:start_loader`
+  - The cache database location can be customised by providing
+    `{database_cache_file, FilePath}` option for `locus_loader`.
 
 ### Local sources: Loading and Updating
 

--- a/src/locus_loader.erl
+++ b/src/locus_loader.erl
@@ -468,7 +468,7 @@ cached_database_path(#state{
                        }
                     )
   when DatabaseCacheFile =/= undefined ->
-  DatabaseCacheFile;
+    DatabaseCacheFile;
 
 cached_database_path(State) ->
     case State#state.origin of

--- a/src/locus_loader.erl
+++ b/src/locus_loader.erl
@@ -340,7 +340,11 @@ validate_loader_opts(MixedOpts, FetcherOpts) ->
               ({database_cache_file, File}) ->
                   % Ensure directory exists
                   Dirname = filename:dirname(File),
-                  filelib:is_dir(Dirname)
+                  (
+                   has_extenstion(File, ["gz", "mmdb"])
+                   and
+                   filelib:is_dir(Dirname)
+                  )
                   orelse error({badopt, Opt});
               (_) ->
                   false
@@ -873,10 +877,14 @@ extract_mmdb_from_tarball_blob(Tarball) ->
 
 -spec has_mmdb_extension(nonempty_string()) -> boolean().
 has_mmdb_extension(Filename) ->
-    case filename_extension_parts(Filename) of
-        ["mmdb"|_] -> true;
-        _ -> false
-    end.
+    has_extenstion(Filename, ["mmdb"]).
+
+% Make sure the ExpectedExtensions list is passed in reverse order.
+% So if file is "archive.tar.gz", the ExpectedExtensions list is ["gz", "tar"].
+-spec has_extenstion(nonempty_string(), [nonempty_string()]) -> boolean().
+has_extenstion(Filename, ExpectedExtensions) ->
+    ExtensionParts = filename_extension_parts(Filename),
+    lists:prefix(ExpectedExtensions, ExtensionParts).
 
 filename_extension_parts(Filename) ->
     filename_extension_parts_recur(Filename, []).

--- a/src/locus_loader.erl
+++ b/src/locus_loader.erl
@@ -338,7 +338,9 @@ validate_loader_opts(MixedOpts, FetcherOpts) ->
               (no_cache) ->
                   true;
               ({database_cache_file, File}) ->
-                  filelib:is_file(File);
+                  % Ensure directory exists
+                  Dirname = filename:dirname(File),
+                  filelib:is_dir(Dirname);
               (_) ->
                   false
           end,

--- a/src/locus_loader.erl
+++ b/src/locus_loader.erl
@@ -340,7 +340,8 @@ validate_loader_opts(MixedOpts, FetcherOpts) ->
               ({database_cache_file, File}) ->
                   % Ensure directory exists
                   Dirname = filename:dirname(File),
-                  filelib:is_dir(Dirname);
+                  filelib:is_dir(Dirname)
+                  orelse error({badopt, Opt});
               (_) ->
                   false
           end,

--- a/src/locus_loader.erl
+++ b/src/locus_loader.erl
@@ -337,7 +337,7 @@ validate_loader_opts(MixedOpts, FetcherOpts) ->
                   orelse error({badopt, Opt});
               (no_cache) ->
                   true;
-              ({database_cache_file, File}) ->
+              ({database_cache_file, File} = Opt) ->
                   % Ensure directory exists
                   Dirname = filename:dirname(File),
                   (


### PR DESCRIPTION
This change allows to customise file path for database cache. The default location remains the same.

The main motivation for this change is the scenario, where remote database is used. If the download fails on first download attempt, there is no fallback. Being able to customise file path allows to ship some fallback database with a release and easily point to it. The default location, which is `user_cache` dir, is harder to provision.